### PR TITLE
fix(backend): create/truncate file writing download summary

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -88,8 +88,9 @@ async fn download(
     let mut download_successful = false;
 
     if let Ok(file) = std::fs::OpenOptions::new()
-        .create_new(true)
         .write(true)
+        .create(true)
+        .truncate(true)
         .open(&summary.file_name)
     {
         let mut writer = std::io::BufWriter::new(file);


### PR DESCRIPTION
Replace create_new with create add truncate when opening summary
file for writing. ensures existing files can be overwritten and avoids
failing the download when the target file already exists. The change also
prevents leftover content by truncating the file before writing.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix download summary file handling: replace create_new with create + truncate so downloads succeed when the target file already exists. The summary file is cleared and overwritten, preventing leftover content.

<!-- End of auto-generated description by cubic. -->

