### PR TITLE
chore(nix): add flake.nix and .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+if has nix; then
+  use flake
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Cargo.lock
 *.diff
 
 .vscode
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777578337,
+        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "Downloader - A simple way to download things via HTTP/HTTPS";
+
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in
+    {
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            nativeBuildInputs = with pkgs; [
+              pkg-config
+              cargo
+              cargo-edit
+              rustc
+              rustfmt
+              clippy
+            ];
+
+            buildInputs = with pkgs; [
+              openssl
+            ];
+          };
+        });
+    };
+}


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MyUsername/downloader/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Nix flake–based dev environment with `direnv` auto-activation for a reproducible Rust toolchain on Linux (x86_64, aarch64). Pins `nixpkgs` via `flake.lock` for consistent onboarding.

- **New Features**
  - Added `flake.nix`/`flake.lock` pinning `nixpkgs` and exposing a Linux devShell with `cargo`, `cargo-edit`, `rustc`, `rustfmt`, `clippy`, `pkg-config`, and `openssl`.
  - Added `.envrc` to auto `use flake` when Nix is available.
  - Updated `.gitignore` to ignore `.direnv`.

<sup>Written for commit e371964abf16e0eb7cdeb032276521621a37b4d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

